### PR TITLE
var len double-defined

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -89,11 +89,11 @@ User.prototype.opentable_gid = function(){
   var cookie_key = this.mobileweb_or_web_key();
   var cookie_subkey = this.mobileweb_or_web_subkey();
   var len = all_cookie_keys.length;
-  for (i = 0; i < len; i++) {
+  for (var i = 0; i < len; i++) {
     if (all_cookie_keys[i].match(cookie_key)) {
       var parts = all_cookie_keys[i].split("&");
-      var len = parts.length;
-      for (var x = 0; x < len; x++) {
+      var len2 = parts.length;
+      for (var x = 0; x < len2; x++) {
         if (parts[x].match(cookie_subkey)) {
           return parts[x].split("=")[1];
         }


### PR DESCRIPTION
This is to fix a bug we found for some specific cookie values. Discussed and manually tested with @jrolfs 